### PR TITLE
ueventd: remove duplicate cpuquiet permisions

### DIFF
--- a/rootdir/ueventd.yoshino.rc
+++ b/rootdir/ueventd.yoshino.rc
@@ -172,11 +172,3 @@
 /sys/module/msm_performance/parameters cpu_max_freq   0664 system system
 /sys/module/msm_performance/parameters cpu_min_freq   0664 system system
 /sys/module/msm_performance/parameters max_cpus       0664 system system
-
-# cpuquiet rqbalance permissions
-/sys/devices/system/cpu/cpuquiet nr_min_cpus                         0660 system system
-/sys/devices/system/cpu/cpuquiet nr_power_max_cpus                   0660 system system
-/sys/devices/system/cpu/cpuquiet nr_thermal_max_cpus                 0660 system system
-/sys/devices/system/cpu/cpuquiet/rqbalance balance_level             0660 system system
-/sys/devices/system/cpu/cpuquiet/rqbalance nr_run_thresholds         0660 system system
-/sys/devices/system/cpu/cpuquiet/rqbalance nr_down_run_thresholds    0660 system system


### PR DESCRIPTION
the cpuquiet permisions are set in init.board.pwr and should not be
duplicated in ueventd.rc

Signed-off-by: Alin Jerpelea <alin.jerpelea@sony.com>